### PR TITLE
Allow v3 of jycr753/ip-utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	"license": "BSD-2-Clause",
 	"require": {
 		"php": ">=5.5.2",
-		"jycr753/ip-utils": "^2.0.1"
+		"jycr753/ip-utils": "^2.0.1 | ^3.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.8"


### PR DESCRIPTION
v3 of jycr753/ip-utils is now released which just drops support for old versions of PHP.